### PR TITLE
Fixed paths and create_output() in example notebook

### DIFF
--- a/notebooks/mni_atlas_reader.ipynb
+++ b/notebooks/mni_atlas_reader.ipynb
@@ -87,7 +87,7 @@
    "outputs": [],
    "source": [
     "%%bash \n",
-    "python mni_atlas_reader/atlas_reader.py -h "
+    "python ../mni_atlas_reader/atlas_reader.py -h "
    ]
   },
   {
@@ -97,7 +97,7 @@
    "outputs": [],
    "source": [
     "%%bash -s \"$stat_img\" \"$outpath\"\n",
-    "python mni_atlas_reader/atlas_reader.py $1 -a Harvard_Oxford -t 5 -c 10 -p 33 -o $2"
+    "python ../mni_atlas_reader/atlas_reader.py $1 -a Harvard_Oxford -t 5 -c 10 -p 33 -o $2"
    ]
   },
   {
@@ -151,8 +151,8 @@
     "from mni_atlas_reader.atlas_reader import create_output\n",
     "\n",
     "create_output(stat_img, ['Harvard_Oxford', 'aal'],\n",
-    "              voxelThresh=3, clusterExtend=10,\n",
-    "              probabilityThreshold=33, outDir=outpath)"
+    "              voxel_thresh=3, cluster_extent=10,\n",
+    "              prob_thresh=33, outdir=outpath)"
    ]
   },
   {
@@ -183,7 +183,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This fix references #32. The notebook works when run from its new directory.