### PR TITLE
Additional plotting options added to create_ouput

### DIFF
--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -599,7 +599,7 @@ def get_statmap_info(stat_img, atlas='all', voxel_thresh=1.96,
 
 def create_output(filename, atlas='all', voxel_thresh=1.96, cluster_extent=20,
                   prob_thresh=5, min_distance=None, outdir=None,
-                  glass_plot_kws, stat_plot_kws):
+                  glass_plot_kws=None, stat_plot_kws=None):
     """
     Performs full cluster / peak analysis on `filename`
 
@@ -664,17 +664,21 @@ def create_output(filename, atlas='all', voxel_thresh=1.96, cluster_extent=20,
     glass_fname = op.join(outdir, '{}.png'.format(out_fname))
     with warnings.catch_warnings():  # get rid of pesky warnings
         warnings.filterwarnings('ignore', category=FutureWarning)
-        glass_plot_kwargs = {
+
+        glass_plot_params = {
             'stat_map_img': thresh_img,
             'output_file': glass_fname,
-            'display_mode': 'lyrz'
+            'display_mode': 'lyrz',
             'colorbar': True,
             'black_bg': True,
             'cmap': plotting.cm.cold_hot,
             'vmax': color_max,
             'plot_abs': False
         }
-        plotting.plot_glass_brain(**glass_plot_kwargs)
+        if glass_plot_kws is None:
+            glass_plot_kws = {}
+        glass_plot_params.update(glass_plot_kws)
+        plotting.plot_glass_brain(**glass_plot_params)
 
     # Check if thresholded image contains only zeros
     if np.any(thresh_img.get_data()):
@@ -702,10 +706,10 @@ def create_output(filename, atlas='all', voxel_thresh=1.96, cluster_extent=20,
         coords = clust_frame[['peak_x', 'peak_y', 'peak_z']].get_values()
         for idx, coord in enumerate(coords):
             clust_fname = '{}_cluster{:02d}.png'.format(out_fname, idx + 1)
-            stat_plot_kwargs = {
+            stat_plot_params = {
                 'stat_map_img': thresh_img,
                 'bg_img': bgimg,
-                'cut_coords': coords,
+                'cut_coords': coord,
                 'output_file': op.join(outdir, clust_fname),
                 'colorbar': True,
                 'title': clust_fname[:-4],
@@ -714,5 +718,7 @@ def create_output(filename, atlas='all', voxel_thresh=1.96, cluster_extent=20,
                 'symmetric_cbar': True,
                 'vmax': color_max
             }
-            plot_params.update(stat_plot_kwargs)
-            plotting.plot_stat_map(**stat_plot_kwargs)
+            if stat_plot_kws is None:
+                stat_plot_kws = {}
+            stat_plot_params.update(stat_plot_kws)
+            plotting.plot_stat_map(**stat_plot_params)

--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -597,43 +597,9 @@ def get_statmap_info(stat_img, atlas='all', voxel_thresh=1.96,
     return clust_frame, peaks_frame
 
 
-def _plot_clusters(img, vmax, title, threshold, output_file, bg_img, coords,
-                    **kwargs):
-    """
-    Wrapper for `nilearn.plotting.plot_stat_map` so users can customize their
-    plots if desired, otherwise default parameters are used.
-
-    See here for future reference: https://stackoverflow.com/a/51940623
-
-    Parameters
-    ----------
-    **kwargs : Arguments for nilearn.plotting.plot_stat_map or dict
-
-    """
-    kwargs.setdefault('black_bg', True)
-    kwargs.setdefault('symmetric_bar', True)
-    plotting.plot_stat_map(**plot_params)
-
-
-def _plot_glass_brain():
-    pass
-
-
-
-
-    plotting.plot_stat_map(
-                thresh_img, vmax=color_max, colorbar=True,
-                title=clust_fname[:-4], threshold=voxel_thresh,
-                output_file=op.join(outdir, clust_fname), bg_img=bgimg,
-                cut_coords=coord, )
-
-
-
-
-
 def create_output(filename, atlas='all', voxel_thresh=1.96, cluster_extent=20,
                   prob_thresh=5, min_distance=None, outdir=None,
-                  glass_plot_kwargs, stat_plot_kwargs):
+                  glass_plot_kws, stat_plot_kws):
     """
     Performs full cluster / peak analysis on `filename`
 

--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -634,6 +634,12 @@ def create_output(filename, atlas='all', voxel_thresh=1.96, cluster_extent=20,
     outdir : str or None, optional
         Path to desired output directory. If None, generated files will be
         saved to the same folder as `filename`. Default: None
+    glass_plot_kws : dict or None, optional
+        Additional keyword arguments to pass to
+        `nilearn.plotting.plot_glass_brain`.
+    glass_plot_kws : dict or None, optional
+        Additional keyword arguments to pass to
+        `nilearn.plotting.plot_stat_map`.
     """
 
     # confirm input data is niimg_like to raise error as early as possible

--- a/atlasreader/tests/test_atlasreader.py
+++ b/atlasreader/tests/test_atlasreader.py
@@ -96,9 +96,6 @@ def test_create_output(tmpdir):
 def test_plotting(tmpdir):
     """Test functionality of kwarg implementation"""
 
-     # create mock data
-    stat_img_name = os.path.basename(STAT_IMG)[:-7]
-
     # temporary output
     output_dir = tmpdir.mkdir('mni_test')
 

--- a/atlasreader/tests/test_atlasreader.py
+++ b/atlasreader/tests/test_atlasreader.py
@@ -91,3 +91,26 @@ def test_create_output(tmpdir):
     assert output_dir.join('{}_clusters.csv'.format(stat_img_name)).isfile()
     assert output_dir.join('{}_peaks.csv'.format(stat_img_name)).isfile()
     assert output_dir.join('{}.png'.format(stat_img_name)).isfile()
+
+
+def test_plotting(tmpdir):
+    """Test functionality of kwarg implementation"""
+
+     # create mock data
+    stat_img_name = os.path.basename(STAT_IMG)[:-7]
+
+    # temporary output
+    output_dir = tmpdir.mkdir('mni_test')
+
+    # overwrite some default params
+    atlasreader.create_output(STAT_IMG,
+                              atlas=['Harvard_Oxford'],
+                              outdir=output_dir,
+                              glass_plot_kws={'display_mode': 'ortho'},
+                              stat_plot_kws={'black_bg': False})
+
+    # add new parameter not already set by default
+    atlasreader.create_output(STAT_IMG,
+                              atlas=['Harvard_Oxford'],
+                              outdir=output_dir,
+                              glass_plot_kws={'alpha': .4})

--- a/notebooks/atlasreader.ipynb
+++ b/notebooks/atlasreader.ipynb
@@ -120,7 +120,7 @@
    "source": [
     "create_output(stat_img,\n",
     "              atlas='aal',\n",
-    "              voxel_thresh=10,\n",
+    "              voxel_thresh=5,\n",
     "              cluster_extent=0,\n",
     "              prob_thresh=0,\n",
     "              outdir='.')"
@@ -282,6 +282,52 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Adjusting the plots\n",
+    "\n",
+    "In addition to changing our selection criteria for the plots, we can also change the style of the plots. We might want to tweak the default plotting style to have a white background, or adjust the colormap used to convey the clusters. This customization is done separately for the glass brain plot and the cluster plots using the `_kws` arguments in `create_output`. These parameters are dictionaries that contain keyword arguments for the `nilearn` functions used to create these plots (see the keyword arguments for [plot_glass_brain](http://nilearn.github.io/modules/generated/nilearn.plotting.plot_glass_brain.html#nilearn.plotting.plot_glass_brain) and [plot_stat_map](http://nilearn.github.io/modules/generated/nilearn.plotting.plot_stat_map.html#nilearn.plotting.plot_stat_map)).\n",
+    "\n",
+    "For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "create_output(stat_img,\n",
+    "              atlas=['Desikan_Killiany', 'Harvard_Oxford'],\n",
+    "              voxel_thresh=5,\n",
+    "              cluster_extent=185,\n",
+    "              prob_thresh=0,\n",
+    "              outdir='.', \n",
+    "              glass_plot_kws={'black_bg': False, 'vmax': 10},\n",
+    "              stat_plot_kws={'black_bg': False, 'title': None})\n",
+    "\n",
+    "Image('image_10426.png')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# title is now removed for all cluster plots\n",
+    "Image('image_10426_cluster01.png')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So, we have flexibility with how we want to select our clusters and how we wish to plot them. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## `atlasreader` from the Command Line\n",
     "\n",
     "This is all super exciting! But as promised before, `atlasreader` can also be run directly from the command line. Assuming you installed it via `pip`.\n",
@@ -396,7 +442,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi all, 

I've added the option of customizing the brain plots, as discussed in #44. `create_output` now has two additional optional arguments, `glass_plot_kws` and `stat_plot_kws`. If they are set (e.g., `glass_plot_kws={'black_bg': False}), these parameters are passed onto the plotting functions within `create_output`. Otherwise, the plots will be shown exactly as how we've had them before. So, this allows users to customize the defaults, if desired, that we've already set. This PR also includes an update to the demo notebook demonstrating this customization capability. 

@rmarkello: This PR does not include any changes to the CLI. I was wondering if you could take a look at how we could best implement this?

