### PR TITLE
ENH: sets symmetric_cbar to false

### DIFF
--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -679,7 +679,8 @@ def create_output(filename, atlas='all', voxel_thresh=1.96, cluster_extent=20,
             'black_bg': True,
             'cmap': plotting.cm.cold_hot,
             'vmax': color_max,
-            'plot_abs': False
+            'plot_abs': False,
+            'symmetric_cbar': False
         }
         if glass_plot_kws is None:
             glass_plot_kws = {}
@@ -721,7 +722,7 @@ def create_output(filename, atlas='all', voxel_thresh=1.96, cluster_extent=20,
                 'title': clust_fname[:-4],
                 'threshold': voxel_thresh,
                 'black_bg': True,
-                'symmetric_cbar': True,
+                'symmetric_cbar': False,
                 'vmax': color_max
             }
             if stat_plot_kws is None:


### PR DESCRIPTION
I prefer the `symmetric_cbar` value to be `False`. Otherwise it can lead to misleading colorlabels:

## Asymmetric color bars
![stat_map_01](https://user-images.githubusercontent.com/950321/45894490-c58c0280-bdce-11e8-9f9b-c3530a0e5d43.png)

## Symmetric color bars
![stat_map_01](https://user-images.githubusercontent.com/950321/45894587-13a10600-bdcf-11e8-907d-2b6b54bf6606.png)

What do others think?

I would of course love to have the vmax for positive and negative to be different, but I don't think that this can be done at the moment.