### PR TITLE
ENH: orders clusters by cluster size

### DIFF
--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -427,7 +427,13 @@ def process_img(stat_img, voxel_thresh=1.96, cluster_extent=20):
     if len(clusters) == 0:
         clusters = [image.new_img_like(thresh_img, data)]
 
-    return image.concat_imgs(clusters)
+    # Reorder clusters by their size
+    clust_img = image.concat_imgs(clusters)
+    cluster_size = (clust_img.get_data() != 0).sum(0).sum(0).sum(0)
+    new_order = np.argsort(cluster_size)[::-1]
+    clust_img_ordered = image.index_img(clust_img, new_order)
+
+    return clust_img_ordered
 
 
 def get_peak_data(clust_img, atlas='all', prob_thresh=5, min_distance=None):

--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -429,7 +429,7 @@ def process_img(stat_img, voxel_thresh=1.96, cluster_extent=20):
 
     # Reorder clusters by their size
     clust_img = image.concat_imgs(clusters)
-    cluster_size = (clust_img.get_data() != 0).sum(0).sum(0).sum(0)
+    cluster_size = (clust_img.get_data() != 0).sum(axis=(0, 1, 2))
     new_order = np.argsort(cluster_size)[::-1]
     clust_img_ordered = image.index_img(clust_img, new_order)
 


### PR DESCRIPTION
Closes https://github.com/miykael/atlasreader/issues/46.

This PR changes the `process_img` output so that the returned cluster image is always ordered by cluster size.