### PR TITLE
REF: Cluster extent not optional

### DIFF
--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -18,8 +18,8 @@ from sklearn.utils import Bunch
 
 
 _ATLASES = [
-    'AAL', 'Desikan_Killiany', 'Destrieux', 'Harvard_Oxford', 'Juelich',
-    'Neuromorphometrics',
+    'aal', 'desikan_killiany', 'destrieux', 'harvard_oxford', 'juelich',
+    'neuromorphometrics',
 ]
 
 
@@ -380,18 +380,18 @@ def read_atlas_cluster(atlastype, cluster, affine, prob_thresh=5):
             percentage[s] >= prob_thresh]
 
 
-def process_img(stat_img, voxel_thresh=1.96, cluster_extent=20):
+def process_img(stat_img, cluster_extent, voxel_thresh=1.96):
     """
     Parameters
     ----------
     stat_img : Niimg_like object
         Thresholded statistical map image
+    cluster_extent : int
+        Minimum number of voxels required to consider a cluster
     voxel_thresh : int, optional
         Threshold to apply to `stat_img`. If a negative number is provided a
         percentile threshold is used instead, where the percentile is
         determined by the equation `100 - voxel_thresh`. Default: 1.96
-    cluster_extent : int, optional
-        Minimum number of voxels required to consider a cluster. Default: 20
 
     Returns
     -------
@@ -530,8 +530,8 @@ def get_cluster_data(clust_img, atlas='all', prob_thresh=5):
     return coord + [clust_mean, cluster_volume] + cluster_info
 
 
-def get_statmap_info(stat_img, atlas='all', voxel_thresh=1.96,
-                     cluster_extent=20, prob_thresh=5, min_distance=None):
+def get_statmap_info(stat_img, cluster_extent, atlas='all', voxel_thresh=1.96,
+                     prob_thresh=5, min_distance=None):
     """
     Extract peaks and cluster information from `clust_img` for `atlas`
 
@@ -539,15 +539,15 @@ def get_statmap_info(stat_img, atlas='all', voxel_thresh=1.96,
     ----------
     stat_img : Niimg_like
         4D image of brain regions, where each volume is a distinct cluster
+    cluster_extent : int
+        Minimum number of contiguous voxels required to consider a cluster in
+        `stat_img`
     atlas : str or list, optional
         Name of atlas(es) to consider for cluster analysis. Default: 'all'
     voxel_thresh : int, optional
         Threshold to apply to `stat_img`. If a negative number is provided a
         percentile threshold is used instead, where the percentile is
         determined by the equation `100 - voxel_thresh`. Default: 1.96
-    cluster_extent : int, optional
-        Minimum number of contiguous voxels required to consider a cluster in
-        `filename`. Default: 20
     prob_thresh : [0, 100] int, optional
         Probability (percentage) threshold to apply to `atlas`, if it is
         probabilistic. Default: 5
@@ -603,7 +603,7 @@ def get_statmap_info(stat_img, atlas='all', voxel_thresh=1.96,
     return clust_frame, peaks_frame
 
 
-def create_output(filename, atlas='all', voxel_thresh=1.96, cluster_extent=20,
+def create_output(filename, cluster_extent, atlas='all', voxel_thresh=1.96,
                   prob_thresh=5, min_distance=None, outdir=None,
                   glass_plot_kws=None, stat_plot_kws=None):
     """
@@ -621,15 +621,15 @@ def create_output(filename, atlas='all', voxel_thresh=1.96, cluster_extent=20,
     ----------
     filename : str
         Path to input statistical map
+    cluster_extent : int
+        Minimum number of contiguous voxels required to consider a cluster in
+        `filename`
     atlas : str or list, optional
         Name of atlas(es) to consider for cluster analysis. Default: 'all'
     voxel_thresh : int, optional
         Threshold to apply to `stat_img`. If a negative number is provided a
         percentile threshold is used instead, where the percentile is
         determined by the equation `100 - voxel_thresh`. Default: 1.96
-    cluster_extent : int, optional
-        Minimum number of contiguous voxels required to consider a cluster in
-        `filename`. Default: 20
     prob_thresh : int, optional
         Probability (percentage) threshold to apply to `atlas`, if it is
         probabilistic. Default: 5

--- a/atlasreader/cli.py
+++ b/atlasreader/cli.py
@@ -3,10 +3,7 @@ Functions for command line interface to generate cluster / peak summary
 """
 import argparse
 import os.path as op
-from atlasreader.atlasreader import (_ATLASES, check_atlases,
-                                     create_output)
-
-_ACCEPTED_ATLASES = _ATLASES + [a.lower() for a in _ATLASES]
+from atlasreader.atlasreader import (_ATLASES, check_atlases, create_output)
 
 
 def _check_limit(num, limits=[0, 100]):
@@ -38,8 +35,11 @@ def _get_parser():
                         help='The full or relative path to the statistical map'
                              'from which cluster information should be '
                              'extracted.')
-    parser.add_argument('-a', '--atlas', type=str, default='all', nargs='+',
-                        choices=_ACCEPTED_ATLASES + ['all'], metavar='atlas',
+    parser.add_argument('cluster_extent', type=int, metavar='min_cluster_size',
+                        help='Number of contiguous voxels required for a '
+                             'cluster to be considered for analysis.')
+    parser.add_argument('-a', '--atlas', type=str.lower, default='all',
+                        nargs='+', choices=_ATLASES + ['all'], metavar='atlas',
                         help='Atlas(es) to use for examining anatomical '
                              'delineation of clusters in provided statistical '
                              'map. Default: all available atlases.')
@@ -48,10 +48,6 @@ def _get_parser():
                         help='Value threshold that voxels in provided file '
                              'must surpass in order to be considered in '
                              'cluster extraction. Default: 2')
-    parser.add_argument('-c', '--cluster', type=float, default=5,
-                        dest='cluster_extent', metavar='extent',
-                        help='Required number of contiguous voxels for a '
-                             'cluster to be retained for analysis. Default: 5')
     parser.add_argument('-p', '--probability', type=_check_limit, default=5,
                         dest='prob_thresh', metavar='threshold',
                         help='Threshold to consider when using a '

--- a/atlasreader/cli.py
+++ b/atlasreader/cli.py
@@ -32,8 +32,8 @@ def _get_parser():
     """ Reads command line arguments and returns input specifications """
     parser = argparse.ArgumentParser()
     parser.add_argument('filename', type=op.abspath, metavar='file',
-                        help='The full or relative path to the statistical map'
-                             'from which cluster information should be '
+                        help='The full or relative path to the statistical '
+                             'map from which cluster information should be '
                              'extracted.')
     parser.add_argument('cluster_extent', type=int, metavar='min_cluster_size',
                         help='Number of contiguous voxels required for a '

--- a/atlasreader/tests/test_atlasreader.py
+++ b/atlasreader/tests/test_atlasreader.py
@@ -61,6 +61,7 @@ def test_get_statmap_info():
     # this will take a little while since it's running it twice
     for min_distance in [None, 20]:
         cdf, pdf = atlasreader.get_statmap_info(nb.load(STAT_IMG),
+                                                cluster_extent=20,
                                                 atlas=['Harvard_Oxford',
                                                        'AAL'],
                                                 min_distance=min_distance)
@@ -68,10 +69,11 @@ def test_get_statmap_info():
 
 def test_process_image():
     # check that defaults for processing image work
-    img = atlasreader.process_img(STAT_IMG)
+    img = atlasreader.process_img(STAT_IMG, cluster_extent=20)
     assert isinstance(img, nb.Nifti1Image)
     # check that negative voxel threshold works
-    img = atlasreader.process_img(STAT_IMG, voxel_thresh=-10)
+    img = atlasreader.process_img(STAT_IMG, cluster_extent=20,
+                                  voxel_thresh=-10)
     assert isinstance(img, nb.Nifti1Image)
 
 
@@ -81,7 +83,7 @@ def test_create_output(tmpdir):
 
     # temporary output
     output_dir = tmpdir.mkdir('mni_test')
-    atlasreader.create_output(STAT_IMG,
+    atlasreader.create_output(STAT_IMG, cluster_extent=20,
                               atlas=['Harvard_Oxford'],
                               outdir=output_dir)
 
@@ -100,14 +102,14 @@ def test_plotting(tmpdir):
     output_dir = tmpdir.mkdir('mni_test')
 
     # overwrite some default params
-    atlasreader.create_output(STAT_IMG,
+    atlasreader.create_output(STAT_IMG, cluster_extent=20,
                               atlas=['Harvard_Oxford'],
                               outdir=output_dir,
                               glass_plot_kws={'display_mode': 'ortho'},
                               stat_plot_kws={'black_bg': False})
 
     # add new parameter not already set by default
-    atlasreader.create_output(STAT_IMG,
+    atlasreader.create_output(STAT_IMG, cluster_extent=20,
                               atlas=['Harvard_Oxford'],
                               outdir=output_dir,
                               glass_plot_kws={'alpha': .4})

--- a/atlasreader/tests/test_cli.py
+++ b/atlasreader/tests/test_cli.py
@@ -13,11 +13,10 @@ def test_cli(tmpdir):
     ret = subprocess.run(['atlasreader',
                           '--atlas', 'harvard_oxford', 'aal',
                           '--threshold', '1.96',
-                          '--cluster', '20',
                           '--probability', '5',
                           '--mindist', '20',
                           '--outdir', output_dir,
-                          STAT_IMG])
+                          STAT_IMG, '20'])
     assert ret.returncode == 0
 
     # test if output exists and if the key .csv and .png files were created

--- a/notebooks/atlasreader.ipynb
+++ b/notebooks/atlasreader.ipynb
@@ -119,9 +119,9 @@
    "outputs": [],
    "source": [
     "create_output(stat_img,\n",
+    "              cluster_extent=0,\n",
     "              atlas='aal',\n",
     "              voxel_thresh=5,\n",
-    "              cluster_extent=0,\n",
     "              prob_thresh=0,\n",
     "              outdir='.')"
    ]
@@ -230,9 +230,9 @@
    "outputs": [],
    "source": [
     "create_output(stat_img,\n",
+    "              cluster_extent=185,\n",
     "              atlas=['Desikan_Killiany', 'Harvard_Oxford'],\n",
     "              voxel_thresh=5,\n",
-    "              cluster_extent=185,\n",
     "              prob_thresh=0,\n",
     "              outdir='.')"
    ]
@@ -296,9 +296,9 @@
    "outputs": [],
    "source": [
     "create_output(stat_img,\n",
+    "              cluster_extent=185,\n",
     "              atlas=['Desikan_Killiany', 'Harvard_Oxford'],\n",
     "              voxel_thresh=5,\n",
-    "              cluster_extent=185,\n",
     "              prob_thresh=0,\n",
     "              outdir='.', \n",
     "              glass_plot_kws={'black_bg': False, 'vmax': 10},\n",
@@ -341,7 +341,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash \n",
+    "%%bash\n",
     "atlasreader -h "
    ]
   },
@@ -361,7 +361,7 @@
    "outputs": [],
    "source": [
     "%%bash -s \"$stat_img\"\n",
-    "atlasreader -a all -t 5 -c 185 -p 40 -o . $1"
+    "atlasreader -a all -t 5 -p 40 -o . $1 185"
    ]
   },
   {
@@ -412,7 +412,7 @@
    "outputs": [],
    "source": [
     "%%bash -s \"$stat_img\"\n",
-    "atlasreader -a all -t 5 -c 185 -p 0 -o . $1"
+    "atlasreader -a all -t 5 -p 0 -o . $1 185"
    ]
   },
   {
@@ -442,7 +442,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
A two-in-one since I was editing `atlasreader.cli`, anyway.

Closes #43. This PR modifies all functions that use the `cluster_extent` parameter to make it a _required_ parameter, and updates tests accordingly. 

Closes #53. This modifies the reading of user-specifies `atlas`es from the command line so that they are automatically converted to a lowercase string (regardless of user specification), reducing the need to specify casing in the accepted list of atlases.