### PR TITLE
ENH: doc fixes and changed default files to have atlasreader as prefix

### DIFF
--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -629,8 +629,8 @@ def create_output(filename, cluster_extent, atlas='all', voxel_thresh=1.96,
 
     Parameters
     ----------
-    filename : str
-        Path to input statistical map
+    filename : Niimg_like
+        A 3D statistical image.
     cluster_extent : int
         Minimum number of contiguous voxels required to consider a cluster in
         `filename`
@@ -668,7 +668,7 @@ def create_output(filename, cluster_extent, atlas='all', voxel_thresh=1.96,
         if outdir is None:
             outdir = op.dirname(filename)
     else:
-        out_fname = 'mniatlasreader'
+        out_fname = 'atlasreader'
         if outdir is None:
             outdir = os.getcwd()
 


### PR DESCRIPTION
Simple fixes for #68. Just changed the documentation for the `filename` parameter in `create_output`, and changed default output prefix to `"atlasreader"`. 

Now that I think about it, the use of `filename` is maybe a misnomer. Perhaps we could change it to `img` to show that it is _not_ just a file name, but can also be any `NIfTI-like` object. Thoughts? 