### PR TITLE
WIP, ENH: Adds `queryatlas` command for coordinates of interest

### DIFF
--- a/atlasreader/cli.py
+++ b/atlasreader/cli.py
@@ -109,8 +109,8 @@ def _queryatlas_parser():
                         help='Threshold to consider when using a '
                              'probabilistic atlas for extracting anatomical '
                              'cluster locations. Value will apply to all '
-                             'request probabilistic atlases, and should range '
-                             'between 0 and 100. Default: 5')
+                             'requested probabilistic atlases, and should '
+                             'range between 0 and 100. Default: 5')
     return parser.parse_args()
 
 
@@ -136,4 +136,5 @@ def queryatlas_main():
 if __name__ == '__main__':
     raise RuntimeError('`atlasreader/cli.py` should not be run '
                        'directly. Please `pip install` atlasreader and '
-                       'use the `atlasreader` command, instead.')
+                       'use the `atlasreader` or `queryatlas` commands, '
+                       'instead.')

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ def main():
         license=ldict['LICENSE'],
         entry_points={
             'console_scripts': [
-                'atlasreader=atlasreader.cli:main'
+                'atlasreader=atlasreader.cli:atlasreader_main',
+                'queryatlas=atlasreader.cli:queryatlas_main'
             ]
         }
     )


### PR DESCRIPTION
Closes #37.

Adds ability to query atlases with a single xyz coordinate (in MNI space) and get a slightly-formatted output of the labels associated with that coordinate for all available (or requested) atlases.

Example usage:
```bash
$ queryatlas 10.3 -20.1 34.8
Atlas                     Label                    
==========                ==========               
aal                       Cingulum_Mid_R
desikan_killiany          Right-Cerebral-White-Matter
destrieux                 Right-Cerebral-White-Matter
harvard_oxford             0% no_label
juelich                   73% WM_Cingulum_R
                          31% WM_Callosal_body
neuromorphometrics        Right_Cerebral_White_Matter
```

Still need to add tests, but wanted to open a PR to see if you have feedback on the idea / implementation / organization.