### PR TITLE
ENH: Add default atlases

### DIFF
--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -29,6 +29,11 @@ _ATLASES = [
     'talairach_gyrus',
 ]
 
+_DEFAULT = [
+    'aal',
+    'desikan_killiany',
+    'harvard_oxford',
+]
 
 def get_atlas(atlastype, cache=True):
     """
@@ -91,7 +96,12 @@ def check_atlases(atlases):
     elif isinstance(atlases, dict):
         if all(hasattr(atlases, i) for i in ['image', 'atlas', 'labels']):
             return atlases
-    draw = atlases if 'all' not in atlases else _ATLASES
+    if 'all' in atlases:
+        draw = _ATLASES
+    elif 'default' in atlases:
+        draw = _DEFAULT
+    else:
+        draw = atlases
 
     return [get_atlas(a) if isinstance(a, str) else a for a in draw]
 
@@ -479,14 +489,14 @@ def process_img(stat_img, cluster_extent, voxel_thresh=1.96):
     return clust_img_ordered
 
 
-def get_peak_data(clust_img, atlas='all', prob_thresh=5, min_distance=None):
+def get_peak_data(clust_img, atlas='default', prob_thresh=5, min_distance=None):
     """
     Parameters
     ----------
     clust_img : Niimg_like
         3D image of a single, valued cluster
     atlas : str or list, optional
-        Name of atlas(es) to consider for cluster analysis. Default: 'all'
+        Name of atlas(es) to consider for cluster analysis. Default: 'default'
     prob_thresh : [0, 100] int, optional
         Probability (percentage) threshold to apply to `atlas`, if it is
         probabilistic. Default: 5
@@ -533,14 +543,14 @@ def get_peak_data(clust_img, atlas='all', prob_thresh=5, min_distance=None):
     return np.column_stack([coords, peak_values, cluster_volume, peak_info])
 
 
-def get_cluster_data(clust_img, atlas='all', prob_thresh=5):
+def get_cluster_data(clust_img, atlas='default', prob_thresh=5):
     """
     Parameters
     ----------
     clust_img : Niimg_like
         3D image of a single, valued cluster
     atlas : str or list, optional
-        Name of atlas(es) to consider for cluster analysis. Default: 'all'
+        Name of atlas(es) to consider for cluster analysis. Default: 'default'
     prob_thresh : [0, 100] int, optional
         Probability (percentage) threshold to apply to `atlas`, if it is
         probabilistic. Default: 5
@@ -573,7 +583,7 @@ def get_cluster_data(clust_img, atlas='all', prob_thresh=5):
     return coord + [clust_mean, cluster_volume] + cluster_info
 
 
-def get_statmap_info(stat_img, cluster_extent, atlas='all', voxel_thresh=1.96,
+def get_statmap_info(stat_img, cluster_extent, atlas='default', voxel_thresh=1.96,
                      prob_thresh=5, min_distance=None):
     """
     Extract peaks and cluster information from `clust_img` for `atlas`
@@ -586,7 +596,7 @@ def get_statmap_info(stat_img, cluster_extent, atlas='all', voxel_thresh=1.96,
         Minimum number of contiguous voxels required to consider a cluster in
         `stat_img`
     atlas : str or list, optional
-        Name of atlas(es) to consider for cluster analysis. Default: 'all'
+        Name of atlas(es) to consider for cluster analysis. Default: 'default'
     voxel_thresh : int, optional
         Threshold to apply to `stat_img`. If a negative number is provided a
         percentile threshold is used instead, where the percentile is
@@ -650,7 +660,7 @@ def get_statmap_info(stat_img, cluster_extent, atlas='all', voxel_thresh=1.96,
     return clust_frame, peaks_frame
 
 
-def create_output(filename, cluster_extent, atlas='all', voxel_thresh=1.96,
+def create_output(filename, cluster_extent, atlas='default', voxel_thresh=1.96,
                   prob_thresh=5, min_distance=None, outdir=None,
                   glass_plot_kws=None, stat_plot_kws=None):
     """
@@ -672,7 +682,7 @@ def create_output(filename, cluster_extent, atlas='all', voxel_thresh=1.96,
         Minimum number of contiguous voxels required to consider a cluster in
         `filename`
     atlas : str or list, optional
-        Name of atlas(es) to consider for cluster analysis. Default: 'all'
+        Name of atlas(es) to consider for cluster analysis. Default: 'default'
     voxel_thresh : int, optional
         Threshold to apply to `stat_img`. If a negative number is provided a
         percentile threshold is used instead, where the percentile is

--- a/atlasreader/cli.py
+++ b/atlasreader/cli.py
@@ -3,7 +3,8 @@ Functions for command line interface to generate cluster / peak summary
 """
 import argparse
 import os.path as op
-from atlasreader.atlasreader import (_ATLASES, check_atlases, create_output)
+from atlasreader.atlasreader import (_ATLASES, _DEFAULT, check_atlases,
+                                     create_output)
 
 
 def _check_limit(num, limits=[0, 100]):
@@ -38,11 +39,13 @@ def _get_parser():
     parser.add_argument('cluster_extent', type=int, metavar='min_cluster_size',
                         help='Number of contiguous voxels required for a '
                              'cluster to be considered for analysis.')
-    parser.add_argument('-a', '--atlas', type=str.lower, default='all',
-                        nargs='+', choices=_ATLASES + ['all'], metavar='atlas',
+    parser.add_argument('-a', '--atlas', type=str.lower, default='default',
+                        nargs='+', choices=_ATLASES + ['all', 'default'],
+                        metavar='atlas',
                         help='Atlas(es) to use for examining anatomical '
                              'delineation of clusters in provided statistical '
-                             'map. Default: all available atlases.')
+                             'map. Default: AAL, Desikan-Killiany & '
+                             'Harvard-Oxford.')
     parser.add_argument('-t', '--threshold', type=float, default=2,
                         dest='voxel_thresh', metavar='threshold',
                         help='Value threshold that voxels in provided file '

--- a/atlasreader/tests/test_atlasreader.py
+++ b/atlasreader/tests/test_atlasreader.py
@@ -53,6 +53,8 @@ def test_get_atlases():
 def test_check_atlases():
     atlases = atlasreader.check_atlases('all')
     assert len(atlases) == len(atlasreader._ATLASES)
+    atlases = atlasreader.check_atlases('default')
+    assert len(atlases) == len(atlasreader._DEFAULT)
     atlases = atlasreader.check_atlases(['aal', 'destrieux'])
     assert atlasreader.check_atlases(atlases) == atlases
     assert atlasreader.check_atlases(atlases[0]) == atlases[0]

--- a/notebooks/atlasreader.ipynb
+++ b/notebooks/atlasreader.ipynb
@@ -384,7 +384,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As we can see, we now get atlas information for all the atlases included in `atlasreader`. Currently those are AAL, FreeSurfer's Desikan-Killiany& Destrieux, FSL's Harvard-Oxford, Juelich and Neuromorphometrics atlas. This is due to the fact that we set the parameter `atlas` to `'all`.\n",
+    "As we can see, we now get atlas information for all the atlases included in `atlasreader`. Currently those are AAL, AICHA, FreeSurfer's Desikan-Killiany & Destrieux, FSL's Harvard-Oxford, Juelich, Neuromorphometrics and Talairach's Brodmann (BA) & Gyrus atlas. This is due to the fact that we set the parameter `atlas` to `'all'`.\n",
     "\n",
     "But what about the `probability threshold` parameter at 40%? This means that only atlas memberships of higher than 40% are shown in the tables:"
    ]


### PR DESCRIPTION
Closes https://github.com/miykael/atlasreader/issues/72.

As discussed in https://github.com/miykael/atlasreader/issues/72, this PR adds default atlases. I'm not sure if the name `default` is the best solution or if we should handle it differently.