### PR TITLE
Rename 'volume' to 'volume_mm' to clarify unit

### DIFF
--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -638,11 +638,11 @@ def get_statmap_info(stat_img, cluster_extent, atlas='all', voxel_thresh=1.96,
     clust_frame = pd.DataFrame(clust_info,
                                columns=['cluster_id',
                                         'peak_x', 'peak_y', 'peak_z',
-                                        'cluster_mean', 'volume'] + atlasnames)
+                                        'cluster_mean', 'volume_mm'] + atlasnames)
     peaks_frame = pd.DataFrame(peaks_info,
                                columns=['cluster_id',
                                         'peak_x', 'peak_y', 'peak_z',
-                                        'peak_value', 'volume'] + atlasnames)
+                                        'peak_value', 'volume_mm'] + atlasnames)
     for col in range(6):
         clust_frame.iloc[:, col] = clust_frame.iloc[:, col].astype(float)
         peaks_frame.iloc[:, col] = peaks_frame.iloc[:, col].astype(float)

--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -638,12 +638,12 @@ def get_statmap_info(stat_img, cluster_extent, atlas='all', voxel_thresh=1.96,
     clust_frame = pd.DataFrame(clust_info,
                                columns=['cluster_id',
                                         'peak_x', 'peak_y', 'peak_z',
-                                        'cluster_mean', 'volume_mm'] \
+                                        'cluster_mean', 'volume_mm']
                                         + atlasnames)
     peaks_frame = pd.DataFrame(peaks_info,
                                columns=['cluster_id',
                                         'peak_x', 'peak_y', 'peak_z',
-                                        'peak_value', 'volume_mm'] \
+                                        'peak_value', 'volume_mm']
                                         + atlasnames)
     for col in range(6):
         clust_frame.iloc[:, col] = clust_frame.iloc[:, col].astype(float)

--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -639,12 +639,12 @@ def get_statmap_info(stat_img, cluster_extent, atlas='all', voxel_thresh=1.96,
                                columns=['cluster_id',
                                         'peak_x', 'peak_y', 'peak_z',
                                         'cluster_mean', 'volume_mm']
-                                        + atlasnames)
+                               + atlasnames)
     peaks_frame = pd.DataFrame(peaks_info,
                                columns=['cluster_id',
                                         'peak_x', 'peak_y', 'peak_z',
                                         'peak_value', 'volume_mm']
-                                        + atlasnames)
+                               + atlasnames)
     for col in range(6):
         clust_frame.iloc[:, col] = clust_frame.iloc[:, col].astype(float)
         peaks_frame.iloc[:, col] = peaks_frame.iloc[:, col].astype(float)

--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -638,11 +638,13 @@ def get_statmap_info(stat_img, cluster_extent, atlas='all', voxel_thresh=1.96,
     clust_frame = pd.DataFrame(clust_info,
                                columns=['cluster_id',
                                         'peak_x', 'peak_y', 'peak_z',
-                                        'cluster_mean', 'volume_mm'] + atlasnames)
+                                        'cluster_mean', 'volume_mm'] \
+                                        + atlasnames)
     peaks_frame = pd.DataFrame(peaks_info,
                                columns=['cluster_id',
                                         'peak_x', 'peak_y', 'peak_z',
-                                        'peak_value', 'volume_mm'] + atlasnames)
+                                        'peak_value', 'volume_mm'] \
+                                        + atlasnames)
     for col in range(6):
         clust_frame.iloc[:, col] = clust_frame.iloc[:, col].astype(float)
         peaks_frame.iloc[:, col] = peaks_frame.iloc[:, col].astype(float)


### PR DESCRIPTION
I just had 15min confusion with the `min_cluster_size` parameter and the volume listed in the tables, until I realized that:

 - `min_cluster_size` expects number of voxels
 - `volume` in the tables represents mm^3

I had voxels of 3x3x3mm, i.e. 27mm per voxel, and clusters with volumes of 216 mm^3. I was so confused why `atlasreader` crashed with ``min_cluster_size`` higher than 8, until I understood the unit difference.

I therefore propose that we use the same unit for both parameters or clarify that volume is in mm^3 (which I try with this PR). What do others think about this issue?
We could also add another variable to the table, called 'volume_vox'?