### PR TITLE
ENH: adds test to check table output

### DIFF
--- a/atlasreader/tests/test_atlasreader.py
+++ b/atlasreader/tests/test_atlasreader.py
@@ -4,6 +4,7 @@ from atlasreader import atlasreader
 import nibabel as nb
 from nilearn.datasets import fetch_neurovault_motor_task
 import pytest
+import hashlib
 
 STAT_IMG = fetch_neurovault_motor_task().images[0]
 EXAMPLE_COORDS = dict(
@@ -153,3 +154,27 @@ def test_plotting(tmpdir):
                               atlas=['Harvard_Oxford'],
                               outdir=output_dir,
                               glass_plot_kws={'alpha': .4})
+
+
+def test_table_output(tmpdir):
+    # create mock data
+    stat_img_name = os.path.basename(STAT_IMG)[:-7]
+
+    # temporary output
+    output_dir = tmpdir.mkdir('mni_test')
+    atlasreader.create_output(STAT_IMG, cluster_extent=20,
+                              atlas=['AAL', 'desikan_killiany',
+                                     'Harvard_Oxford'],
+                              outdir=output_dir)
+
+    # test if output tables contain expected output
+    cluster_checksum = hashlib.md5(
+        open(output_dir.join('{}_clusters.csv'.format(stat_img_name)),
+        'rb').read()).hexdigest()
+
+    peak_checksum = hashlib.md5(
+        open(output_dir.join('{}_peaks.csv'.format(stat_img_name)),
+        'rb').read()).hexdigest()
+
+    assert cluster_checksum == '5d85805d58f8fbe22ef4e34ec75d8f42'
+    assert peak_checksum == 'f7cd664571413fe964eef0c45cd6f033'

--- a/atlasreader/tests/test_atlasreader.py
+++ b/atlasreader/tests/test_atlasreader.py
@@ -174,5 +174,5 @@ def test_table_output(tmpdir):
     peak_checksum = hashlib.md5(open(output_dir.join(
         '{}_peaks.csv'.format(stat_img_name)), 'rb').read()).hexdigest()
 
-    assert cluster_checksum == '5d85805d58f8fbe22ef4e34ec75d8f42'
+    assert cluster_checksum == 'b03705caeaad17b3cbc9f9b6042bdd72'
     assert peak_checksum == 'f7cd664571413fe964eef0c45cd6f033'

--- a/atlasreader/tests/test_atlasreader.py
+++ b/atlasreader/tests/test_atlasreader.py
@@ -175,4 +175,4 @@ def test_table_output(tmpdir):
         '{}_peaks.csv'.format(stat_img_name)), 'rb').read()).hexdigest()
 
     assert cluster_checksum == 'b03705caeaad17b3cbc9f9b6042bdd72'
-    assert peak_checksum == 'f7cd664571413fe964eef0c45cd6f033'
+    assert peak_checksum == '061b505b6a505053e4e8e4e25d051b1a'

--- a/atlasreader/tests/test_atlasreader.py
+++ b/atlasreader/tests/test_atlasreader.py
@@ -168,13 +168,11 @@ def test_table_output(tmpdir):
                               outdir=output_dir)
 
     # test if output tables contain expected output
-    cluster_checksum = hashlib.md5(
-        open(output_dir.join('{}_clusters.csv'.format(stat_img_name)),
-        'rb').read()).hexdigest()
+    cluster_checksum = hashlib.md5(open(output_dir.join(
+        '{}_clusters.csv'.format(stat_img_name)), 'rb').read()).hexdigest()
 
-    peak_checksum = hashlib.md5(
-        open(output_dir.join('{}_peaks.csv'.format(stat_img_name)),
-        'rb').read()).hexdigest()
+    peak_checksum = hashlib.md5(open(output_dir.join(
+        '{}_peaks.csv'.format(stat_img_name)), 'rb').read()).hexdigest()
 
     assert cluster_checksum == '5d85805d58f8fbe22ef4e34ec75d8f42'
     assert peak_checksum == 'f7cd664571413fe964eef0c45cd6f033'


### PR DESCRIPTION
This PR adds a test to check if the tables create the output that we expect them to create. The checksum that is included in the test is based on the current output and might need to be adapted if we find future bugs. But like this, we will always know when the table output changes.