### PR TITLE
ENH: make cluster extent inclusive

### DIFF
--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -461,7 +461,7 @@ def process_img(stat_img, cluster_extent, voxel_thresh=1.96):
             try:
                 clusters += [connected_regions(
                     image.new_img_like(thresh_img, data),
-                    min_region_size=min_region_size,
+                    min_region_size=min_region_size - 1e-8,
                     extract_type='connected_components')[0]]
             except TypeError:  # for no clusters
                 pass


### PR DESCRIPTION
It seems that the `min_cluster_size` parameter was exclusive, i.e. if a cluster size of 100mm^3 was specified, then clusters of 100mm^3 were not shown. I assume that this is due to some rounding issue and comparisons of floats issue.

Reducing the `min_region_size` value of `nilearn.regions`'s `connected_regions` function by `1e-8` was in my case enough to take care of this.
