### PR TITLE
ENH: removes some more numpy warnings

### DIFF
--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -744,7 +744,15 @@ def create_output(filename, cluster_extent, atlas='all', voxel_thresh=1.96,
         if glass_plot_kws is None:
             glass_plot_kws = {}
         glass_plot_params.update(glass_plot_kws)
-        plotting.plot_glass_brain(**glass_plot_params)
+        try:
+            # catch UserWarning: empty mask
+            warnings.filterwarnings('error')
+            plotting.plot_glass_brain(**glass_plot_params)
+        except Warning:
+            if thresh_img.get_data().sum() == 0:
+                warning_msg = "UserWarning: The thresholded image is empty! "
+                warning_msg += "No clusters detected."
+                print(warning_msg)
 
     # Check if thresholded image contains only zeros
     if np.any(thresh_img.get_data()):

--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -744,15 +744,7 @@ def create_output(filename, cluster_extent, atlas='all', voxel_thresh=1.96,
         if glass_plot_kws is None:
             glass_plot_kws = {}
         glass_plot_params.update(glass_plot_kws)
-        try:
-            # catch UserWarning: empty mask
-            warnings.filterwarnings('error')
-            plotting.plot_glass_brain(**glass_plot_params)
-        except Warning:
-            if thresh_img.get_data().sum() == 0:
-                warning_msg = "UserWarning: The thresholded image is empty! "
-                warning_msg += "No clusters detected."
-                print(warning_msg)
+        plotting.plot_glass_brain(**glass_plot_params)
 
     # Check if thresholded image contains only zeros
     if np.any(thresh_img.get_data()):

--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -436,14 +436,18 @@ def process_img(stat_img, cluster_extent, voxel_thresh=1.96):
         4D image of brain regions, where each volume is a distinct cluster
     """
     # get input data image
-    stat_img = image.index_img(check_niimg(stat_img, atleast_4d=True), 0)
+    img_4d = check_niimg(stat_img, atleast_4d=True)
+    if img_4d.shape[-1] == 1:
+        stat_img = img_4d.slicer[..., 0]
+    else:
+        stat_img = image.index_img(img_4d, 0)
 
     # threshold image
     if voxel_thresh < 0:
         voxel_thresh = '{}%'.format(100 + voxel_thresh)
     else:
         # ensure that threshold is not greater than most extreme value in image
-        if voxel_thresh > np.abs(stat_img.get_data()).max():
+        if voxel_thresh > np.nan_to_num(np.abs(stat_img.get_data())).max():
             empty = np.zeros(stat_img.shape + (1,))
             return image.new_img_like(stat_img, empty)
     thresh_img = image.threshold_img(stat_img, threshold=voxel_thresh)


### PR DESCRIPTION
While running `atlasreader` in my system, I've encountered multiple `numpy` warnings:

```
~/anaconda3/lib/python3.6/site-packages/numpy/core/_methods.py:26:
  RuntimeWarning: invalid value encountered in reduce
  return umr_maximum(a, axis, None, out, keepdims)
```

This PR takes care of these.

### Issue 1
I'm not sure why `image.index_img(img_4d, 0)` threw this error if the `img_4d` originally was only a 3D image, but the changes take care of this error.

### Issue 2
The second correction is more important. I had to add a `nan_to_num` transformation, as some niftis might include `nan`. Especially the ones from SPM. This means that the `if` condition `voxel_thresh > np.abs(stat_img.get_data()).max()` was always `False`,  the moment `stat_img` contains `nan`.