### PR TITLE
Revert "ENH: Adds license message on first import"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,3 @@ dist/*
 localtest
 .pytest_cache/
 .ipynb_checkpoints
-.vscode/
-.imported

--- a/atlasreader/__init__.py
+++ b/atlasreader/__init__.py
@@ -2,26 +2,3 @@ __all__ = ['__version__', 'create_output', 'get_statmap_info']
 
 from atlasreader.info import __version__
 from atlasreader.atlasreader import create_output, get_statmap_info
-
-_LICENSE_MESSAGE = """\
-The Python package you are importing, `atlasreader`, is licensed under the
-BSD-3 license; however, the atlases it uses are separately licensed under more
-restrictive frameworks.
-
-By using `atlasreader`, you agree to abide by the license terms of the
-individual atlases. Information on these terms can be found online at
-https://github.com/miykael/atlasreader.
-"""
-
-
-def _first_import():
-    import os.path as op
-    from pkg_resources import resource_filename
-    imported = resource_filename('atlasreader', 'data/.imported')
-    if not op.exists(imported):
-        print(_LICENSE_MESSAGE)
-        with open(imported, 'w'):
-            pass
-
-
-_first_import()

--- a/atlasreader/tests/test_cli.py
+++ b/atlasreader/tests/test_cli.py
@@ -17,7 +17,7 @@ def test_cli(tmpdir):
                           '--mindist', '20',
                           '--outdir', output_dir,
                           STAT_IMG, '20'])
-    assert ret.returncode == 1
+    assert ret.returncode == 0
 
     # test if output exists and if the key .csv and .png files were created
     assert output_dir.exists()


### PR DESCRIPTION
Tests on TravisCI were failing because of the license check introduced with PR https://github.com/miykael/atlasreader/pull/71. This was the case for **general tests** (https://travis-ci.org/miykael/atlasreader/jobs/476838506) as well as for tests in the **notebook** (https://travis-ci.org/miykael/atlasreader/jobs/476838507).