### PR TITLE
Add license text from PR #71 to __init__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/*
 localtest
 .pytest_cache/
 .ipynb_checkpoints
+.vscode/

--- a/atlasreader/__init__.py
+++ b/atlasreader/__init__.py
@@ -2,3 +2,14 @@ __all__ = ['__version__', 'create_output', 'get_statmap_info']
 
 from atlasreader.info import __version__
 from atlasreader.atlasreader import create_output, get_statmap_info
+
+_LICENSE_MESSAGE = """\
+The Python package you are importing, `atlasreader`, is licensed under the
+BSD-3 license; however, the atlases it uses are separately licensed under more
+restrictive frameworks.
+By using `atlasreader`, you agree to abide by the license terms of the
+individual atlases. Information on these terms can be found online at:
+https://github.com/miykael/atlasreader/tree/master/atlasreader/data
+"""
+
+print(_LICENSE_MESSAGE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib
 nibabel
-nilearn>=0.5.0a
+nilearn==0.5.0a
 numpy
 pandas
 scipy


### PR DESCRIPTION
This PR continues the work under https://github.com/miykael/atlasreader/pull/71, by adding the license text to the `__init__.py` file. But in contrast to https://github.com/miykael/atlasreader/pull/71, this PR will not create an `.imported` file, but print the license text the first time the module is loaded within an environment.