### PR TITLE
[FIX] rounding issue 

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -28,6 +28,11 @@
       "orcid": "0000-0001-5507-4304"
     },
     {
+      "affiliation": "Department of Psychology, University of Bielefeld, Bielefeld, Germany.",
+      "name": "Doll, Anna",
+      "orcid": "0000-0002-0799-0831"
+    },
+    {
       "name": "Whitaker, Kirstie",
       "affiliation": "Alan Turing Institute, London, UK; Department of Psychiatry, University of Cambridge, Cambridge, UK",
       "orcid": "0000-0001-8498-4059"

--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -194,7 +194,8 @@ def coord_xyz_to_ijk(affine, coords):
         Provided `coords` in cartesian space
     """
     coords = _check_coord_inputs(coords)
-    vox_coords = np.linalg.solve(affine, coords)[:3].T.astype(int)
+    vox_coords = np.linalg.solve(affine, coords)[:3].T
+    vox_coords = np.round(vox_coords).astype(int)
     return vox_coords
 
 
@@ -227,7 +228,7 @@ def get_peak_coords(clust_img):
         maxcoords[n] = center_of_mass(cluster == cluster.max())
 
     # sort peak coordinates by cluster size
-    maxcoords = np.floor(maxcoords)[np.argsort(clust_size)[::-1]]
+    maxcoords = np.round(maxcoords).astype(int)[np.argsort(clust_size)[::-1]]
 
     # convert coordinates to MNI space
     coords = coord_ijk_to_xyz(clust_img.affine, maxcoords)
@@ -260,7 +261,7 @@ def get_subpeak_coords(clust_img, min_distance=20):
     # make new clusters to check for "flat" peaks + find CoM of those clusters
     labels, nl = label(local_max)
     ijk = center_of_mass(data, labels=labels, index=range(1, nl + 1))
-    ijk = np.asarray(ijk, dtype=int)
+    ijk = np.round(ijk).astype(int)
 
     if len(ijk) > 1:
         # sort coordinates based on peak value

--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -228,7 +228,7 @@ def get_peak_coords(clust_img):
         maxcoords[n] = center_of_mass(cluster == cluster.max())
 
     # sort peak coordinates by cluster size
-    maxcoords = np.round(maxcoords).astype(int)[np.argsort(clust_size)[::-1]]
+    maxcoords = np.floor(maxcoords).astype(int)[np.argsort(clust_size)[::-1]]
 
     # convert coordinates to MNI space
     coords = coord_ijk_to_xyz(clust_img.affine, maxcoords)
@@ -440,8 +440,8 @@ def read_atlas_cluster(atlastype, cluster, affine, prob_thresh=5):
 
     sortID = np.argsort(percentage)[::-1]
 
-    return [[percentage[s], labels[s]] for s in sortID]
-
+    return [[percentage[s], labels[s]] for s in sortID if
+            percentage[s] >= prob_thresh]
 
 def process_img(stat_img, cluster_extent, voxel_thresh=1.96, direction='both'):
     """

--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -443,6 +443,7 @@ def read_atlas_cluster(atlastype, cluster, affine, prob_thresh=5):
     return [[percentage[s], labels[s]] for s in sortID if
             percentage[s] >= prob_thresh]
 
+
 def process_img(stat_img, cluster_extent, voxel_thresh=1.96, direction='both'):
     """
     Parameters


### PR DESCRIPTION
Dear all,

I found a bug for an edge condition in atlasreader. I think this is due to a rounding error (or rather no rounding but only changing float to integers without rounding at all). The two tables below show the peak table with the current implementation of atlasreader, where the Amygdala peak has a 1-p value of 0.  After implementing rounding of the coordinates the Amygdala gets the correct value of 1-p = 0.9996.

I hope this help,
Anna

Before the fix:
```
	cluster_id	peak_x	peak_y	peak_z	peak_value	volume_mm	harvard_oxford
0	1	21.5	-12.5	-16.5	0.9998	6744	81% Right_Hippocampus
1	1	27.5	-34.5	-0.5	0.9990	6744	62% Right_Hippocampus
2	2	-24.5	-14.5	-16.5	0.9998	5816	92% Left_Hippocampus
3	2	-22.5	-6.5	-28.5	0.9812	5816	36% Left_Hippocampus; 30% Left_Parahippocampal_Gyrus_anterior_division
4	2	-32.5	-2.5	-24.5	0.0000	5816	25% Left_Amygdala
```

After rounding floats before converting them to integers:
```
0 	1 	23.5 	-10.5 	-16.5 	0.9998 	6744 	38% Right_Hippocampus; 25% Right_Amygdala
1 	1 	27.5 	-34.5 	-0.5 	0.9990 	6744 	54% Right_Hippocampus
2 	2 	-24.5 	-14.5 	-14.5 	0.9998 	5816 	42% Left_Hippocampus
3 	2 	-30.5 	-0.5 	-24.5 	0.9996 	5816 	58% Left_Amygdala
4 	2 	-22.5 	-6.5 	-28.5 	0.9812 	5816 	47% Left_Hippocampus
```