### PR TITLE
explicit warning on voxel threshold too high

### DIFF
--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -490,7 +490,9 @@ def process_img(stat_img, cluster_extent, voxel_thresh=1.96, direction="both"):
         voxel_thresh = f"{100 + voxel_thresh}%"
     else:
         # ensure that threshold is not greater than most extreme value in image
-        if voxel_thresh > np.nan_to_num(np.abs(stat_img.get_fdata())).max():
+        max_data_val = np.nan_to_num(np.abs(stat_img.get_fdata())).max()
+        if voxel_thresh > max_data_val:
+            warnings.warn(f"Threshold value '{voxel_thresh}' is greater than max value in image '{max_data_val}'. Will select zero voxels.")
             empty = np.zeros(stat_img.shape + (1,))
             return image.new_img_like(stat_img, empty)
     thresh_img = image.threshold_img(stat_img, threshold=voxel_thresh)

--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -492,7 +492,9 @@ def process_img(stat_img, cluster_extent, voxel_thresh=1.96, direction="both"):
         # ensure that threshold is not greater than most extreme value in image
         max_data_val = np.nan_to_num(np.abs(stat_img.get_fdata())).max()
         if voxel_thresh > max_data_val:
-            warnings.warn(f"Threshold value '{voxel_thresh}' is greater than max value in image '{max_data_val}'. Will select zero voxels.")
+            warn_msg = f"Threshold value '{voxel_thresh}' is greater than max value in image '{max_data_val}'."
+            warn_msg += " Will select zero voxels."
+            warnings.warn(warn_msg)
             empty = np.zeros(stat_img.shape + (1,))
             return image.new_img_like(stat_img, empty)
     thresh_img = image.threshold_img(stat_img, threshold=voxel_thresh)


### PR DESCRIPTION
Hey there, 
I just started using the library and had trouble getting started (couldn't replicate the notebook). The issue had to do with the default value for `voxel_thresh`.
In particular when the default value is too high no voxel is selected and the error/warning is propagated down to nilearn and it was not immediatly clear to me what was causing the issue from `atlasreader`.

```
/~/workspace/test/venv/lib/python3.12/site-packages/nilearn/plotting/displays/_slicers.py:313: UserWarning: empty mask
  ims = self._map_show(img, type="imshow", threshold=threshold, **kwargs)
```

I've added an explicit warning in order to hopefully make things more clear

```
~/workspace/test/venv/lib/python3.12/site-packages/atlasreader/atlasreader.py:495: UserWarning: Threshold value '1.96' is greater than max value in image '1.374666452407837'. Will select zero voxels.
  warnings.warn(f"Threshold value '{voxel_thresh}' is greater than max value in image '{max_data_val}'. Will select zero voxels.")
/~/workspace/test/venv/lib/python3.12/site-packages/nilearn/plotting/displays/_slicers.py:313: UserWarning: empty mask
  ims = self._map_show(img, type="imshow", threshold=threshold, **kwargs)
```

Let me know if you think this could be helpful, thanks for the awesome work!